### PR TITLE
Fix residual resolve color and luminance handling across ColorStrength

### DIFF
--- a/shaders.hlsl
+++ b/shaders.hlsl
@@ -139,21 +139,7 @@ void CS_Resolve(uint3 id : SV_DispatchThreadID)
     float3 smallInput = gSmallInput.SampleLevel(gLinear, uv, 0).rgb;
     float3 smallOutput = gSmallOutput.SampleLevel(gLinear, uv, 0).rgb;
 
-    // 3. Compute neural delta / edit
-    float3 edit = smallOutput - smallInput;
-
-    // Chroma vs Luma control for ColorStrength
-    float editLuma = dot(edit, kLuma);
-    float3 editChroma = edit - editLuma;
-    float3 controlledEdit = editLuma + editChroma * saturate(gColorStrength);
-
-    // Apply TransferStrength
-    float3 scaledEdit = controlledEdit * gTransferStrength;
-
-    // Base native frame + scaled neural delta
-    float3 result = max(original + scaledEdit, 0.0);
-
-    // 4. HDR highlight & shadow guard using luminance ratio
+    // Luminance values
     float origLuma = dot(max(original, 0.0), kLuma);
     float inLuma   = dot(max(smallInput, 0.0), kLuma);
     float outLuma  = dot(max(smallOutput, 0.0), kLuma);
@@ -161,6 +147,14 @@ void CS_Resolve(uint3 id : SV_DispatchThreadID)
     const float kFloor = 1.0 / 512.0;
     float lumaRatio = (outLuma + kFloor) / (inLuma + kFloor);
 
+    // 3. Resolve calculation branch
+    float brightnessScale = pow(lumaRatio, gTransferStrength);
+
+    float3 lumaScaledResult  = max((original + kFloor) * brightnessScale - kFloor, 0.0);
+    float3 colorDeltaResult  = max(original + (smallOutput - smallInput) * gTransferStrength, 0.0);
+    float3 result = lerp(lumaScaledResult, colorDeltaResult, saturate(gColorStrength));
+
+    // 4. HDR highlight & shadow guard using luminance ratio
     float resLuma = dot(result, kLuma);
     if (resLuma > 1e-5 && inLuma > 1e-5)
     {


### PR DESCRIPTION
#### The Problem with Low Color (`ColorStrength -> 0.0`)
Previously, isolating brightness was done by stripping chroma and adding a uniform luminance scalar equally across all channels: $\text{Native} + \Delta L$. 

This is mathematically flawed for brightness adjustment:
* **Desaturation:** Adding equal white light across RGB dilutes chromaticity, making brightened areas look chalky and faded.

Multiplicative luminance scaling ($\text{Native} \times \frac{L_{\text{out}}}{L_{\text{in}}}$) avoids this by scaling channels proportionally, preserving native hue, saturation, and deep shadow contrast.

---

At full color, a direct per-channel additive residual `Native + (Output - Input)` is the correct approach.

---

#### Solution
The resolve now smoothly blends (`lerp`) between pure multiplicative luminance scaling at `0.0` and the full additive residual at `1.0`. 

This keeps shadows deep and saturation intact when color transfer is minimized, preserves the exact model output when color transfer is maximized, and eliminates slider popping across the entire range.