### PR TITLE
Fix uniform 150% and 200% scales bypassing the NR scaling path

### DIFF
--- a/proxy_main.cpp
+++ b/proxy_main.cpp
@@ -974,9 +974,9 @@ static int EvaluateFeatureInternal(
     float currentScaleX = isAnamorphic ? g_scaleX.load() : currentScale;
     float currentScaleY = isAnamorphic ? g_scaleY.load() : currentScale;
 
-    bool isNativePassthrough = !isAnamorphic
-        ? (currentScale >= 0.999f)
-        : (fabsf(currentScaleX - 1.0f) < 0.005f && fabsf(currentScaleY - 1.0f) < 0.005f);
+    // Match the native-size tolerance used for workW/workH in both scaling modes.
+    bool isNativePassthrough =
+        (fabsf(currentScaleX - 1.0f) < 0.005f && fabsf(currentScaleY - 1.0f) < 0.005f);
 
     // Pass through directly to real DLL when proxy is disabled OR scale is 100% native
     if (!g_enableProxy.load() || isNativePassthrough) {


### PR DESCRIPTION
Uniform 150% and 200% currently take the native passthrough branch. The uniform-mode condition is `currentScale >= 0.999f`, so every scale above native returns through the caller's original feature before the proxy can allocate scaled textures or create its scaled NR feature.

This change checks both effective axis scales against 1.0, using the same `fabsf(scale - 1.0f) < 0.005f` tolerance already used by `workW` and `workH`. Uniform supersampling then reaches the existing scaling path, just as equivalent anamorphic scales already do.

For a 3200 x 1800 NR input with the proxy enabled:

| Setting | Before | After |
| --- | --- | --- |
| Uniform 75% | 2400 x 1350 | 2400 x 1350 |
| Uniform 100% | Native passthrough | Native passthrough |
| Uniform 150% | Native passthrough, 3200 x 1800 | 4800 x 2700 |
| Uniform 200% | Native passthrough, 3200 x 1800 | 6400 x 3600 |
| Anamorphic 85% x 65% | 2720 x 1170 | 2720 x 1170 |

One consistency change near native is intentional: a uniform value such as 0.996 now takes the direct native path, matching the dimension calculation's existing snap to native. Previously it entered the proxy with native working dimensions. The existing strict tolerance is retained; no new threshold is introduced.

The companion's uniform preset buttons are already inside `if (!s_enableAnamorphic)`, so no UI change is needed.

Validation against upstream `9bb03663d690b84ec00cdb55fb3a1a04dd881e02`:

- Compiled a local C++ harness containing the effective-scale selection, native/disabled branch condition, and work-dimension statements extracted unchanged from `proxy_main.cpp`. These were compiled as C++, not reimplemented in another language. All 25 cases pass after the patch; five fail on the original source, including both advertised supersampling presets, an odd-sized supersampling case, and two near-native consistency cases.
- Cases include uniform 25/65/75/85/100/150/200%, near-native values on both sides of the tolerance, anamorphic native/reduced/enlarged/mixed axes, disabled proxy, odd source dimensions, and the minimum work size. This harness tests branch selection and dimensions only; it does not call D3D12 or NGX.
- Built and linked the full x64 proxy from both source versions with MSVC 19.29, the existing shader headers, and the repository's release compiler/linker flags. Both builds completed without compiler/linker warnings or errors.
- `git diff --check` passes.

No model DLL or game was loaded during validation. Acceptance of larger NR features by a particular model/driver, GPU memory use, performance, and image quality still need runtime testing. This restores the advertised supersampling path; it does not establish a visual-quality improvement. At 150% and 200%, that path requests 2.25x and 4x the native pixel count respectively. The existing resource/feature failure handling is unchanged.
